### PR TITLE
Refactor home page structure to match login layout pattern

### DIFF
--- a/src/modules/Home/pages/HomePage.js
+++ b/src/modules/Home/pages/HomePage.js
@@ -1,0 +1,32 @@
+import React, { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useDispatch } from "react-redux";
+import { useTranslation } from "react-i18next";
+import CourseListFormPage from "../../Course/pages/CourseListFormPage";
+import { showFloatingError } from "../../../shared/store/rootActions";
+import { useAuth } from "../../../shared/utils/authProvider";
+
+const HomePage = () => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { isLoggedIn, isLoading } = useAuth();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!isLoading && !isLoggedIn) {
+      router.push("/login");
+    }
+  }, [isLoading, isLoggedIn, router]);
+
+  if (isLoading) {
+    return <div>{t("loading")}</div>;
+  }
+
+  const handleError = (errorMessage) => {
+    dispatch(showFloatingError(errorMessage));
+  };
+
+  return <CourseListFormPage handleError={handleError} />;
+};
+
+export default HomePage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,39 +1,14 @@
-import React, { useState, useEffect } from "react";
-import { useRouter } from "next/router";
-import { useDispatch } from "react-redux";
-import { showFloatingError } from "../shared/store/rootActions";
-import { useAuth } from "../shared/utils/authProvider";
-import CourseListFormPage from "../modules/Course/pages/CourseListFormPage";
 import SidebarLayout from "../shared/layouts/sidebarlayout/SidebarLayout";
-import { useTranslation } from "react-i18next"; // Importing useTranslation
 import SidebarHelpButton from "../shared/layouts/components/sidebar/SidebarHelpButton";
 import SidebarHomeButton from "../shared/layouts/components/sidebar/SidebarHomeButton";
+import HomePage from "../modules/Home/pages/HomePage";
 
-const HomePage = () => {
-  const { t } = useTranslation(); // Using the translation hook
-  const router = useRouter();
-  const { isLoggedIn, isLoading } = useAuth();
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    if (!isLoading && !isLoggedIn) {
-      router.push("/login");
-    }
-  }, [isLoggedIn, isLoading, router]);
-
-  if (isLoading) {
-    return <div>{t("loading")}</div>; // Using translation key for loading message
-  }
-
-  const handleError = (errorMessage) => {
-    dispatch(showFloatingError(errorMessage));
-  };
-
+const Home = () => {
   return (
     <SidebarLayout menuButtons={[SidebarHomeButton, SidebarHelpButton]}>
-      <CourseListFormPage handleError={handleError} />
+      <HomePage />
     </SidebarLayout>
   );
 };
 
-export default HomePage;
+export default Home;


### PR DESCRIPTION
## Summary
- move the home page logic into a dedicated module component that mirrors the login page structure
- update the Next.js home route to simply compose the sidebar layout with the new module component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc3fbf718083218e1a599d39a84f53