### PR TITLE
Refactor home page structure to match login layout pattern

### DIFF
--- a/src/modules/Home/pages/HomePage.js
+++ b/src/modules/Home/pages/HomePage.js
@@ -1,0 +1,32 @@
+import React, { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useDispatch } from "react-redux";
+import { showFloatingError } from "../../../shared/store/rootActions";
+import { useAuth } from "../../../shared/utils/authProvider";
+import CourseListFormPage from "../../Course/pages/CourseListFormPage";
+import { useTranslation } from "react-i18next";
+
+const HomePage = () => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { isLoggedIn, isLoading } = useAuth();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!isLoading && !isLoggedIn) {
+      router.push("/login");
+    }
+  }, [isLoggedIn, isLoading, router]);
+
+  if (isLoading) {
+    return <div>{t("loading")}</div>;
+  }
+
+  const handleError = (errorMessage) => {
+    dispatch(showFloatingError(errorMessage));
+  };
+
+  return <CourseListFormPage handleError={handleError} />;
+};
+
+export default HomePage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,39 +1,15 @@
-import React, { useState, useEffect } from "react";
-import { useRouter } from "next/router";
-import { useDispatch } from "react-redux";
-import { showFloatingError } from "../shared/store/rootActions";
-import { useAuth } from "../shared/utils/authProvider";
-import CourseListFormPage from "../modules/Course/pages/CourseListFormPage";
+import React from "react";
 import SidebarLayout from "../shared/layouts/sidebarlayout/SidebarLayout";
-import { useTranslation } from "react-i18next"; // Importing useTranslation
 import SidebarHelpButton from "../shared/layouts/components/sidebar/SidebarHelpButton";
 import SidebarHomeButton from "../shared/layouts/components/sidebar/SidebarHomeButton";
+import HomePage from "../modules/Home/pages/HomePage";
 
-const HomePage = () => {
-  const { t } = useTranslation(); // Using the translation hook
-  const router = useRouter();
-  const { isLoggedIn, isLoading } = useAuth();
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    if (!isLoading && !isLoggedIn) {
-      router.push("/login");
-    }
-  }, [isLoggedIn, isLoading, router]);
-
-  if (isLoading) {
-    return <div>{t("loading")}</div>; // Using translation key for loading message
-  }
-
-  const handleError = (errorMessage) => {
-    dispatch(showFloatingError(errorMessage));
-  };
-
+const Home = () => {
   return (
     <SidebarLayout menuButtons={[SidebarHomeButton, SidebarHelpButton]}>
-      <CourseListFormPage handleError={handleError} />
+      <HomePage />
     </SidebarLayout>
   );
 };
 
-export default HomePage;
+export default Home;


### PR DESCRIPTION
## Summary
- move the home page logic into a new module page to mirror the login view structure
- update the Next.js index page to focus on applying the Sidebar layout around the home module content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc42f67b8c8321ac87b52e75c0b849